### PR TITLE
fix(cd): improve tag message extraction for GitHub releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,14 @@ jobs:
         run: |
           # Extract tag name and release notes from tag annotation
           TAG_NAME="${{ github.ref_name }}"
-          TAG_MESSAGE=$(git tag -l --format='%(contents)' $TAG_NAME)
+
+          # Use git for-each-ref for reliable tag message extraction
+          TAG_MESSAGE=$(git for-each-ref "refs/tags/$TAG_NAME" --format='%(contents)')
+
+          # Fallback to commit message if tag annotation is empty
+          if [ -z "$TAG_MESSAGE" ]; then
+            TAG_MESSAGE=$(git log -1 --format='%B' "$TAG_NAME")
+          fi
 
           # Create GitHub Release with the tag's annotation
           gh release create "$TAG_NAME" \


### PR DESCRIPTION
## Summary

- Fixed unreliable tag annotation extraction in CD workflow
- Uses `git for-each-ref` instead of `git tag -l` for more consistent results
- Added fallback to commit message if tag annotation is empty

## Problem

The v1.2.0 release was created with only the commit message instead of the full tag annotation. This happened because `git tag -l --format='%(contents)'` can be unreliable in CI environments.

## Solution

- Switched to `git for-each-ref` which is more reliable for extracting tag contents
- Added a fallback mechanism to use commit message if annotation is empty

## Test Plan

- [x] Verify workflow syntax is valid
- [ ] Test with next release to confirm tag annotations appear correctly