### PR TITLE
fix(security): remove hardcoded secrets from docker-compose.yml

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,11 @@
+# Docker Compose environment variables
+# Copy this file to .env.docker and fill in your values:
+#   cp .env.docker.example .env.docker
+# DO NOT commit .env.docker to version control
+
+# Resend email service (get key from https://resend.com/api-keys)
+RESEND_TOKEN=your_resend_api_key_here
+RESEND_FROM=hello@opentribe.io
+
+# Better Auth (generate with: openssl rand -base64 32)
+BETTER_AUTH_SECRET=your_secret_here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,10 +40,10 @@ services:
     environment:
       NODE_ENV: development
       DATABASE_URL: postgresql://opentribe:opentribe_dev@postgres:5432/opentribe
-      BETTER_AUTH_SECRET: rq+MmXcamqhjGCda/lW1sd6H9PiUYu4Vzlw51c0ohjg=
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
       BETTER_AUTH_URL: http://localhost:3002
-      RESEND_FROM: hello@opentribe.io
-      RESEND_TOKEN: re_hN2zcNEh_MAdkQQqMjj7BerPVjXC45UL3
+      RESEND_FROM: ${RESEND_FROM:-hello@opentribe.io}
+      RESEND_TOKEN: ${RESEND_TOKEN}
       NEXT_PUBLIC_API_URL: http://localhost:3002
       NEXT_PUBLIC_WEB_URL: http://localhost:3000
       NEXT_PUBLIC_DASHBOARD_URL: http://localhost:3001
@@ -81,7 +81,7 @@ services:
     environment:
       NODE_ENV: development
       DATABASE_URL: postgresql://opentribe:opentribe_dev@postgres:5432/opentribe
-      BETTER_AUTH_SECRET: rq+MmXcamqhjGCda/lW1sd6H9PiUYu4Vzlw51c0ohjg=
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
       BETTER_AUTH_URL: http://localhost:3002
       NEXT_PUBLIC_API_URL: http://localhost:3002
       NEXT_PUBLIC_DASHBOARD_URL: http://localhost:3001
@@ -120,7 +120,7 @@ services:
     environment:
       NODE_ENV: development
       DATABASE_URL: postgresql://opentribe:opentribe_dev@postgres:5432/opentribe
-      BETTER_AUTH_SECRET: rq+MmXcamqhjGCda/lW1sd6H9PiUYu4Vzlw51c0ohjg=
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
       BETTER_AUTH_URL: http://localhost:3002
       NEXT_PUBLIC_API_URL: http://localhost:3002
       NEXT_PUBLIC_WEB_URL: http://localhost:3000


### PR DESCRIPTION
## Summary

Removes exposed **Resend API key** and **BETTER_AUTH_SECRET** from `docker-compose.yml` by replacing them with environment variable references.

Closes #147

## Changes

- **`docker-compose.yml`** — Replaced 5 hardcoded secrets with `${VAR}` references:
  - `RESEND_TOKEN` → `${RESEND_TOKEN}`
  - `RESEND_FROM` → `${RESEND_FROM:-hello@opentribe.io}` (with default)
  - `BETTER_AUTH_SECRET` → `${BETTER_AUTH_SECRET}` (3 services)
- **`.env.docker.example`** — New template file for local Docker setup

## ⚠️ Action Required (assignee: @yogesh)

### 1. Rotate Exposed API Keys
The following keys were publicly exposed and **must be rotated** at [resend.com/api-keys](https://resend.com/api-keys):

| Key (masked) | Found in |
|---|---|
| `re_hN2zcNEh_...5UL3` | `docker-compose.yml` (line 46) |
| `re_PKmg3jbd_...VjddA` | `.env.local` files |

### 2. Generate New BETTER_AUTH_SECRET
```bash
openssl rand -base64 32
```

### 3. Update Local Environment
After merging, all developers must:
1. Create `.env.docker` from the new template:
   ```bash
   cp .env.docker.example .env.docker
   ```
2. Fill in the new rotated keys

## Git History Note

The leaked secrets also exist in git history. A follow-up step using `git filter-repo` is recommended to scrub them. This requires coordination with all collaborators (re-clone).

## Recommendation

Consider adding [**git-secrets**](https://github.com/awslabs/git-secrets) or a pre-commit hook to prevent future leaks:
```bash
brew install git-secrets
git secrets --install
git secrets --register-aws
```