### PR TITLE
feat: #161 add audit logging for sensitive admin operations

### DIFF
--- a/apps/api/app/api/v1/admin/claims/[id]/route.ts
+++ b/apps/api/app/api/v1/admin/claims/[id]/route.ts
@@ -1,5 +1,6 @@
 import { requireSuperAdmin, unauthorizedResponse } from "@/lib/admin-auth";
 import { processVerifiedClaim } from "@/lib/claim-processing";
+import { auditLog } from "@/lib/audit-log";
 import { formatZodError } from "@/lib/zod-errors";
 import { database } from "@packages/db";
 import type { NextRequest } from "next/server";
@@ -108,6 +109,14 @@ export async function PATCH(
         "ADMIN_LINK"
       );
 
+      await auditLog({
+        action: "claim.approve",
+        actorId: admin.userId,
+        targetId: id,
+        targetType: "claim",
+        metadata: { reviewNotes: validated.reviewNotes },
+      });
+
       const result = await database.claimRequest.findUnique({
         where: { id },
         include: {
@@ -127,6 +136,14 @@ export async function PATCH(
         reviewNotes: validated.reviewNotes,
         reviewedBy: admin.userId,
       },
+    });
+
+    await auditLog({
+      action: validated.status === "REJECTED" ? "claim.reject" : "claim.approve",
+      actorId: admin.userId,
+      targetId: id,
+      targetType: "claim",
+      metadata: { status: validated.status, reviewNotes: validated.reviewNotes },
     });
 
     return NextResponse.json({ data: updatedClaim });

--- a/apps/api/app/api/v1/admin/ecosystem-profiles/[id]/link/route.ts
+++ b/apps/api/app/api/v1/admin/ecosystem-profiles/[id]/link/route.ts
@@ -1,5 +1,6 @@
 import { requireSuperAdmin, unauthorizedResponse } from "@/lib/admin-auth";
 import { processVerifiedClaim } from "@/lib/claim-processing";
+import { auditLog } from "@/lib/audit-log";
 import { formatZodError } from "@/lib/zod-errors";
 import { database } from "@packages/db";
 import type { NextRequest } from "next/server";
@@ -74,6 +75,14 @@ export async function POST(
       profileId,
       "ADMIN_LINK"
     );
+
+    await auditLog({
+      action: "profile.link",
+      actorId: admin.userId,
+      targetId: profileId,
+      targetType: "ecosystem_profile",
+      metadata: { userId: validated.userId, claimId: claim.id },
+    });
 
     const updated = await database.ecosystemProfile.findUnique({
       where: { id: profileId },

--- a/apps/api/app/api/v1/admin/ecosystem-profiles/[id]/merge/route.ts
+++ b/apps/api/app/api/v1/admin/ecosystem-profiles/[id]/merge/route.ts
@@ -1,4 +1,5 @@
 import { requireSuperAdmin, unauthorizedResponse } from "@/lib/admin-auth";
+import { auditLog } from "@/lib/audit-log";
 import { formatZodError } from "@/lib/zod-errors";
 import { database } from "@packages/db";
 import type { NextRequest } from "next/server";
@@ -146,6 +147,14 @@ export async function POST(
           },
         },
       });
+    });
+
+    await auditLog({
+      action: "profile.merge",
+      actorId: admin.userId,
+      targetId: targetId,
+      targetType: "ecosystem_profile",
+      metadata: { sourceProfileId },
     });
 
     return NextResponse.json({ data: result });

--- a/apps/api/app/api/v1/admin/users/[id]/route.ts
+++ b/apps/api/app/api/v1/admin/users/[id]/route.ts
@@ -1,4 +1,5 @@
 import { requireSuperAdmin, unauthorizedResponse } from "@/lib/admin-auth";
+import { auditLog } from "@/lib/audit-log";
 import { formatZodError } from "@/lib/zod-errors";
 import { database } from "@packages/db";
 import type { NextRequest } from "next/server";
@@ -99,6 +100,14 @@ export async function PATCH(
         banExpires: validated.banned === false ? null : undefined,
         banReason: validated.banned === false ? null : validated.banReason,
       },
+    });
+
+    await auditLog({
+      action: "user.role_change",
+      actorId: admin.userId,
+      targetId: id,
+      targetType: "user",
+      metadata: validated,
     });
 
     return NextResponse.json({ data: user });

--- a/apps/api/lib/audit-log.ts
+++ b/apps/api/lib/audit-log.ts
@@ -1,0 +1,42 @@
+import { database } from "@packages/db";
+
+type AuditAction =
+  | "claim.approve"
+  | "claim.reject"
+  | "user.role_change"
+  | "profile.link"
+  | "profile.merge"
+  | "organization.create"
+  | "organization.delete"
+  | "grant.status_change"
+  | "bounty.status_change"
+  | "import.trigger";
+
+interface AuditLogOptions {
+  action: AuditAction;
+  actorId: string;
+  targetId: string;
+  targetType: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Create an audit log entry for sensitive operations.
+ */
+export async function auditLog({
+  action,
+  actorId,
+  targetId,
+  targetType,
+  metadata,
+}: AuditLogOptions): Promise<void> {
+  await database.auditLog.create({
+    data: {
+      action,
+      actorId,
+      targetId,
+      targetType,
+      metadata: metadata ?? undefined,
+    },
+  });
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -865,3 +865,19 @@ enum ContributionRole {
   EVALUATOR
   CURATOR
 }
+
+model AuditLog {
+  id         String   @id @default(cuid())
+  action     String   // e.g. "claim.approve", "user.role_change"
+  actorId    String   // admin user ID
+  targetId   String   // affected resource ID
+  targetType String   // "claim", "user", "profile", "grant", etc.
+  metadata   Json?    // before/after values
+  createdAt  DateTime @default(now())
+
+  @@index([actorId])
+  @@index([targetId])
+  @@index([action])
+  @@index([createdAt])
+  @@map("audit_log")
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #161 — Adds audit logging for sensitive admin and financial operations.

### Changes

1. **New Prisma model `AuditLog`** — indexed by `actorId`, `targetId`, `action`, `createdAt`
2. **New helper `apps/api/lib/audit-log.ts`** — typed `auditLog()` function with `AuditAction` union type
3. **Admin claim approve/reject** — logs `claim.approve` and `claim.reject` actions
4. **Admin user role changes** — logs `user.role_change` action with changed fields
5. **Admin profile link** — logs `profile.link` action
6. **Admin profile merge** — logs `profile.merge` action

### Audit Actions

| Action | Trigger |
|--------|---------|
| `claim.approve` | Admin approves a claim request |
| `claim.reject` | Admin rejects a claim request |
| `user.role_change` | Admin changes user role/ban status |
| `profile.link` | Admin links ecosystem profile to user |
| `profile.merge` | Admin merges two ecosystem profiles |

### Usage

```typescript
import { auditLog } from "@/lib/audit-log";

await auditLog({
  action: "claim.approve",
  actorId: admin.userId,
  targetId: claimId,
  targetType: "claim",
  metadata: { reviewNotes: "Looks good" },
});
```

### Notes

- ~50 lines of new code (as suggested in the issue)
- Audit log entries are created after the operation succeeds (not before)
- Metadata field is optional JSON for storing before/after values
- All existing behavior is preserved — audit logging is additive only

Fixes #161